### PR TITLE
ci(renovate): require 7-day minimum release age for upgrades

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,6 @@
 {
   "extends": ["config:base"],
+  "minimumReleaseAge": "7 days",
   "regexManagers": [
     {
       "fileMatch": ["^\\.pre-commit-hooks\\.yaml$"],
@@ -10,4 +11,3 @@
     }
   ]
 }
-


### PR DESCRIPTION
Mitigate supply chain attacks by waiting 7 days before adopting any new dependency release. Most compromised packages (Shai-Hulud, ua-parser-js, eslint-config-prettier, etc.) are detected and yanked within hours-to-days of publication, so a release-age delay catches the overwhelming majority of malicious releases.

Security alerts bypass this delay by default — Renovate's `vulnerabilityAlerts` config overrides `minimumReleaseAge` to `null` and sets `prCreation: immediate`, so CVE fixes still ship without waiting.

Mirrors the equivalent change in the monorepo: Mergifyio/mergify#31013.